### PR TITLE
Fix mail parsing and improve search utils

### DIFF
--- a/src/agent/agent_slack_mail.py
+++ b/src/agent/agent_slack_mail.py
@@ -42,9 +42,7 @@ class AgentSlackMail(AgentGPT):
             if res.status_code == 200:
                 mail_content = res.content.decode("utf-8", errors="replace")
                 mail_content = html.unescape(mail_content)
-                subject, content = scraping_utils.Site = scraping_utils.scraping_text(
-                    mail_content
-                )
+                subject, content = scraping_utils.scraping_text(mail_content)
                 mail_content = content
 
         subject = mail.get("subject", "")

--- a/src/utils/slack_search_utils.py
+++ b/src/utils/slack_search_utils.py
@@ -8,7 +8,7 @@ PAGE_COUNT = 100
 
 def search_messages(slack_cli, query, num=10) -> List[str]:
     if not query or not num:
-        return
+        return []
     search_results = []
     page: int = int(num / PAGE_COUNT) + 2
     for i in range(1, page):


### PR DESCRIPTION
## Summary
- correct scraping call in `AgentSlackMail`
- ensure `search_messages` returns list when query/num missing

## Testing
- `python -m py_compile src/agent/agent_slack_mail.py src/utils/slack_search_utils.py`