### PR TITLE
Fix Mail scraping text assignment

### DIFF
--- a/src/agent/agent_slack_mail.py
+++ b/src/agent/agent_slack_mail.py
@@ -42,9 +42,7 @@ class AgentSlackMail(AgentGPT):
             if res.status_code == 200:
                 mail_content = res.content.decode("utf-8", errors="replace")
                 mail_content = html.unescape(mail_content)
-                subject, content = scraping_utils.Site = scraping_utils.scraping_text(
-                    mail_content
-                )
+                subject, content = scraping_utils.scraping_text(mail_content)
                 mail_content = content
 
         subject = mail.get("subject", "")


### PR DESCRIPTION
## Summary
- fix mis-assigned return from `scraping_text` in `AgentSlackMail`

## Testing
- `pytest -q` *(fails: command not found)*