### PR TITLE
Add Slack bookmark when posting email

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,5 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/bulldra/slack-sub-bot)
+
+## 変更点
+
+* メールを受信して投稿したメッセージに対して自動的にSlackのブックマークを追加し、未読管理をしやすくしました。

--- a/src/agent/agent_slack_mail.py
+++ b/src/agent/agent_slack_mail.py
@@ -25,6 +25,25 @@ class AgentSlackMail(AgentGPT):
         self._openai_model: str = "got-4.1"
         self._mail: Mail
 
+    def execute(self, arguments: dict[str, Any], chat_history: list[Chat]) -> Chat:
+        """Execute the agent and add a bookmark for the posted message."""
+        result = super().execute(arguments, chat_history)
+        try:
+            if self._ts:
+                self._slack.api_call(
+                    "bookmarks.add",
+                    json={
+                        "channel": self._channel,
+                        "title": self._mail.subject or "mail",
+                        "type": "message",
+                        "entity_id": self._ts,
+                        "emoji": ":email:",
+                    },
+                )
+        except Exception as err:  # pragma: no cover - skip test for Slack API
+            self._logger.error("failed to add bookmark: %s", err)
+        return result
+
     def build_prompt(
         self, arguments: dict[str, Any], chat_history: List[dict[str, Any]]
     ) -> List[ChatCompletionMessageParam]:

--- a/tests/agent/test_agent_slack_mail.py
+++ b/tests/agent/test_agent_slack_mail.py
@@ -3,6 +3,7 @@ import json
 import os
 
 import pytest
+from unittest import mock
 
 from agent.agent_slack_mail import AgentSlackMail
 
@@ -42,3 +43,18 @@ def test_gpt(pytestconfig: pytest.Config):
     prompt = agent.build_prompt({}, messages)
     print(prompt)
     print(agent.completion(prompt))
+
+
+def test_execute_adds_bookmark(pytestconfig: pytest.Config):
+    os.chdir(pytestconfig.getini("pythonpath")[0])
+    context = {"channel": "C123", "ts": "123.45", "thread_ts": "123.45"}
+    agent = AgentSlackMail(context)
+    messages = [
+        {
+            "role": "user",
+            "content": json.dumps({"plain_text": "body", "subject": "sub"}),
+        }
+    ]
+    with mock.patch.object(agent._slack, "api_call") as mock_call:
+        agent.execute({}, messages)
+        mock_call.assert_called()


### PR DESCRIPTION
## Summary
- bookmark Slack messages created by the mail agent
- document the new feature
- add regression test for bookmark call (merged into existing file)

## Testing
- `pytest -q` *(fails: `pytest` not found)*
