### PR TITLE
Switch default model to gpt-4.1

### DIFF
--- a/src/agent/agent_gpt.py
+++ b/src/agent/agent_gpt.py
@@ -25,7 +25,7 @@ class AgentGPT(AgentSlack):
             raise ValueError("environment not defined.")
         self._secrets: dict = json.loads(secrets)
         self._context: dict[str, Any] = context
-        self._openai_model: str = "gpt-4.1-mini"
+        self._openai_model: str = "gpt-4.1"
         self._openai_temperature: float = 0.0
         self._output_max_token: int = 30000
         self._max_token: int = 128000 // 2 - self._output_max_token

--- a/src/agent/agent_idea.py
+++ b/src/agent/agent_idea.py
@@ -14,7 +14,7 @@ class AgentIdea(AgentGPT):
     def __init__(self, context: dict[str, Any]) -> None:
         super().__init__(context)
         self._openai_stream = True
-        self._openai_model: str = "gpt-4.1-mini"
+        self._openai_model: str = "gpt-4.1"
 
     def build_prompt(
         self, arguments: dict[str, Any], chat_history: List[Chat]

--- a/src/agent/agent_recommend.py
+++ b/src/agent/agent_recommend.py
@@ -13,7 +13,7 @@ class AgentRecommend(AgentGPT):
     def __init__(self, context: dict[str, Any]) -> None:
         super().__init__(context)
         self._openai_stream = True
-        self._openai_model: str = "gpt-4.1-mini"
+        self._openai_model: str = "gpt-4.1"
         self._openai_temperature: float = 0.5
         self._keywords: List[str] = []
 

--- a/src/agent/agent_slack_mail.py
+++ b/src/agent/agent_slack_mail.py
@@ -22,7 +22,7 @@ class AgentSlackMail(AgentGPT):
     def __init__(self, context: dict[str, Any]) -> None:
         super().__init__(context)
         self._openai_stream = False
-        self._openai_model: str = "gpt-4.1-mini"
+        self._openai_model: str = "gpt-4.1"
         self._mail: Mail
 
     def build_prompt(

--- a/src/agent/agent_summarize.py
+++ b/src/agent/agent_summarize.py
@@ -13,7 +13,7 @@ class AgentSummarize(AgentGPT):
 
     def __init__(self, context: dict[str, Any]) -> None:
         super().__init__(context)
-        self._openai_model: str = "gpt-4.1-mini"
+        self._openai_model: str = "gpt-4.1"
         self._openai_stream = False
         self._site: Optional[scraping_utils.SiteInfo] = None
 

--- a/src/function/generative_agent.py
+++ b/src/function/generative_agent.py
@@ -29,7 +29,7 @@ class AgentExecute(NamedTuple):
 class GenerativeAgent(GenerativeBase):
     def __init__(self) -> None:
         super().__init__()
-        self._openai_model: str = "gpt-4.1-mini"
+        self._openai_model: str = "gpt-4.1"
 
     def generate(
         self, command: Optional[str], chat_history: list[Chat]

--- a/src/function/generative_base.py
+++ b/src/function/generative_base.py
@@ -19,7 +19,7 @@ class GenerativeBase:
     def __init__(self) -> None:
         self._secrets: dict = json.loads(str(os.getenv("SECRETS")))
         self._openai_client = openai.OpenAI(api_key=self._secrets.get("OPENAI_API_KEY"))
-        self._openai_model: str = "gpt-4.1-mini"
+        self._openai_model: str = "gpt-4.1"
         self._openai_temperature: float = 0.0
         self._logger: logging.Logger = logging.getLogger(__name__)
         self._logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Summary
- migrate from `got-4.1` to `gpt-4.1` for all agents and generative classes

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*