### PR TITLE
Improve URL recognition

### DIFF
--- a/src/utils/slack_link_utils.py
+++ b/src/utils/slack_link_utils.py
@@ -36,10 +36,18 @@ def is_contains_url(text: str) -> bool:
 
 
 def is_only_url(text: str) -> bool:
-    if is_contains_url(text):
-        text = re.sub(r"<([^|>]+).*>$", "\\1", text)
-        return parse_url(text) == extract_url(text)
-    else:
+    """Return True if the text consists solely of a URL."""
+    if not text:
+        return False
+
+    if not is_contains_url(text):
+        return False
+
+    sanitized = re.sub(r"^<([^|>]+)(?:\|[^>]*)?>$", r"\1", text.strip())
+
+    try:
+        return parse_url(sanitized) == extract_url(text)
+    except ValueError:
         return False
 
 

--- a/tests/utils/test_slack_link_utils.py
+++ b/tests/utils/test_slack_link_utils.py
@@ -25,6 +25,14 @@ def test_is_only_url():
             argument="<https://www.example.com/?utm_medium=1&amp;gclid=1dd|aa>",
             expected=True,
         ),
+        Case(
+            argument=" https://www.example.com/ ",
+            expected=True,
+        ),
+        Case(
+            argument="<https://www.example.com/>\n",
+            expected=True,
+        ),
         Case(argument="あいう<https://www.example.com/?a=1&a=2|aa>", expected=False),
     ]
     for case in case_list:


### PR DESCRIPTION
## Summary
- enhance URL detection to handle slack-styled links with extra whitespace
- expand tests for `is_only_url` edge cases

## Testing
- `pytest tests/utils/test_slack_link_utils.py::test_is_only_url -q` *(fails: `pytest: command not found`)*