### PR TITLE
Fix typos and rename persist

### DIFF
--- a/src/agent/agent_base.py
+++ b/src/agent/agent_base.py
@@ -29,7 +29,7 @@ class AgentSlack(Agent):
     def __init__(self, context: dict[str, Any]) -> None:
         secrets: str = str(os.getenv("SECRETS"))
         if not secrets:
-            raise ValueError("envirament not define.")
+            raise ValueError("environment not defined")
         self._secrets: dict = json.loads(secrets)
         self._slack_user_id = context.get("user_id")
         self._slack: slack_sdk.WebClient = slack_sdk.WebClient(

--- a/src/utils/stored_gcs.py
+++ b/src/utils/stored_gcs.py
@@ -16,7 +16,7 @@ class StoredGcs:
         try:
             self._blob = storage.Client().get_bucket(bucket_name).blob(blob_name)
         except DefaultCredentialsError:
-            print("crential not setttings")
+            print("credentials not set")
 
     def is_exists(self) -> bool:
         if not self._blob:
@@ -39,7 +39,7 @@ class StoredGcs:
             return self._blob.download_as_text()
         return None
 
-    def parsist(self, text: str, content_type="application/json") -> None:
+    def persist(self, text: str, content_type="application/json") -> None:
         if not self._blob:
             return
         self._blob.upload_from_string(text, content_type=content_type)

--- a/src/utils/weather.py
+++ b/src/utils/weather.py
@@ -27,7 +27,7 @@ class Weather:
             )
             if response.status_code == 200:
                 content = response.text
-                gcs.parsist(content)
+                gcs.persist(content)
             elif gcs.is_exists():
                 content = gcs.download_as_string()
 


### PR DESCRIPTION
## Summary
- minor typo fixes in agent and utils
- rename `parsist` method to `persist`

## Testing
- `pytest -q` *(fails: command not found)*