### PR TITLE
Add site text to history after summarization

### DIFF
--- a/src/agent/agent_summarize.py
+++ b/src/agent/agent_summarize.py
@@ -42,6 +42,12 @@ class AgentSummarize(AgentGPT):
             prompt = prompt_template.substitute(replace_dict)
             return super().build_prompt(arguments, [Chat(role="user", content=prompt)])
 
+    def execute(self, arguments: dict[str, Any], chat_history: list[Chat]) -> Chat:
+        result = super().execute(arguments, chat_history)
+        if self._site and self._site.content:
+            chat_history.append(Chat(role="assistant", content=self._site.content))
+        return result
+
     def build_message_blocks(self, content: str) -> list:
         if self._site is None:
             raise ValueError("site is empty")


### PR DESCRIPTION
## Summary
- ensure AgentSummarize stores scraped site text in chat history

## Testing
- `pytest -q` *(fails: command not found)*