### PR TITLE
Use pydantic for internal data models

### DIFF
--- a/src/agent/agent_slack_mail.py
+++ b/src/agent/agent_slack_mail.py
@@ -1,7 +1,9 @@
 import html
 import json
 from string import Template
-from typing import Any, List, NamedTuple
+from typing import Any, List
+
+from pydantic import BaseModel
 
 import requests
 from openai.types.chat import ChatCompletionMessageParam
@@ -11,10 +13,13 @@ from agent.agent_gpt import AgentGPT
 from agent.types import Chat
 
 
-class Mail(NamedTuple):
+class Mail(BaseModel):
     from_name: str
     subject: str
     content: str
+
+    class Config:
+        allow_mutation = False
 
 
 class AgentSlackMail(AgentGPT):

--- a/src/agent/types.py
+++ b/src/agent/types.py
@@ -1,8 +1,18 @@
-from typing import Literal, TypedDict
+from typing import Literal
+
+from pydantic import BaseModel
 
 __all__ = ["Chat"]
 
-
-class Chat(TypedDict):
+class Chat(BaseModel):
     role: Literal["system", "user", "assistant"]
     content: str
+
+    class Config:
+        allow_mutation = False
+
+    def __getitem__(self, item: str):
+        return getattr(self, item)
+
+    def get(self, item: str, default=None):
+        return getattr(self, item, default)

--- a/src/function/generative_agent.py
+++ b/src/function/generative_agent.py
@@ -1,5 +1,7 @@
 import json
-from typing import Any, NamedTuple, Optional
+from typing import Any, Optional
+
+from pydantic import BaseModel
 
 from openai.types.chat import ChatCompletionMessageParam
 from openai.types.responses.function_tool_param import FunctionToolParam
@@ -22,9 +24,13 @@ from agent.types import Chat
 from function.generative_base import GenerativeBase
 
 
-class AgentExecute(NamedTuple):
+class AgentExecute(BaseModel):
     agent: type[Agent]
     arguments: dict[str, Any]
+
+    class Config:
+        allow_mutation = False
+        arbitrary_types_allowed = True
 
 
 class GenerativeAgent(GenerativeBase):

--- a/src/utils/scraping_utils.py
+++ b/src/utils/scraping_utils.py
@@ -2,17 +2,22 @@ import os
 import re
 import tempfile
 import urllib
-from typing import NamedTuple, Optional, Tuple
+from typing import Optional, Tuple
+
+from pydantic import BaseModel
 
 import pypdf
 import requests
 from bs4 import BeautifulSoup
 
 
-class SiteInfo(NamedTuple):
+class SiteInfo(BaseModel):
     url: str = ""
     title: str = ""
     content: Optional[str] = None
+
+    class Config:
+        allow_mutation = False
 
 
 def is_allow_scraping(url: str) -> bool:


### PR DESCRIPTION
## Summary
- convert Chat to a pydantic `BaseModel`
- convert Mail, AgentExecute and SiteInfo to pydantic models

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*