### PR TITLE
Add CI for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r src/requirements.txt
+
+      - name: Create secrets file
+        if: ${{ secrets.SECRETS_JSON != '' }}
+        run: echo '${{ secrets.SECRETS_JSON }}' > secrets.json
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest on pushes and PRs

## Testing
- `pip install -r src/requirements.txt` *(fails: Could not find a version that satisfies the requirement annotated-types==0.7.0)*
- `pytest -q` *(fails: command not found)*