### PR TITLE
Trigger deploy after tests pass

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -1,12 +1,16 @@
 name: Deploy Cloud Run
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Test"]
     branches: ["main"]
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,16 @@
 name: Deploy
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Test"]
     branches: ["main"]
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pytest
 
 ## Usage
 
-Deploy the Cloud Function using `deploy.sh`, or deploy as a Cloud Run service with `deploy_cloudrun.sh`. Deployment can also be automated through the GitHub Actions workflows. You can invoke it locally with `functions-framework`:
+Deploy the Cloud Function using `deploy.sh`, or deploy as a Cloud Run service with `deploy_cloudrun.sh`. Deployment can also be automated through the GitHub Actions workflows. The deployment workflows run automatically after the test workflow succeeds. You can invoke it locally with `functions-framework`:
 
 ```bash
 functions-framework --target main --signature-type cloudevent


### PR DESCRIPTION
## Summary
- set deploy workflows to trigger after the `Test` workflow
- allow manual dispatch of deploy workflows
- document the workflow chain in README

## Testing
- `pip install -r src/requirements.txt` *(fails: Could not find a version that satisfies the requirement annotated-types==0.7.0)*