### PR TITLE
Update CI to set secrets env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r src/requirements.txt
 
+            - name: Set env for secrets
+              run: echo "SECRETS_JSON=${{ secrets.SECRETS_JSON }}" >> $GITHUB_ENV
+
             - name: Create secrets file
               run: |
                   if [ -n "${{ secrets.SECRETS_JSON }}" ]; then

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Example:
 export SECRETS='{"SLACK_BOT_TOKEN":"xoxb-...","SLACK_USER_TOKEN":"xoxp-...","OPENAI_API_KEY":"sk-..."}'
 ```
 
+### GitHub Actions
+
+For tests running on GitHub Actions, store the same JSON string in a repository
+secret named `SECRETS_JSON`. The `test.yml` workflow writes this value to
+`secrets.json` before executing `pytest`.
+
 3. Run tests
 
 ```bash


### PR DESCRIPTION
## Summary
- configure the test workflow to export `SECRETS_JSON`

## Testing
- `black .`
- `uv run pytest` *(fails: No route to host)*