### PR TITLE
Handle GCS config via secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,13 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r src/requirements.txt
 
+            - name: Create GCS bucket config
+              run: |
+                  if [ -n '${{ secrets.GCS_BUCKET_JSON }}' ]; then
+                    mkdir -p src/conf
+                    echo '${{ secrets.GCS_BUCKET_JSON }}' > src/conf/gcs_bucket.json
+                  fi
+
             - name: Set up Cloud SDK
               uses: google-github-actions/setup-gcloud@v1
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,12 @@ jobs:
                     echo '${{ secrets.SECRETS_JSON }}' > secrets.json
                   fi
 
+            - name: Create GCS bucket config
+              run: |
+                  if [ -n '${{ secrets.GCS_BUCKET_JSON }}' ]; then
+                    mkdir -p src/conf
+                    echo '${{ secrets.GCS_BUCKET_JSON }}' > src/conf/gcs_bucket.json
+                  fi
+
             - name: Run tests
               run: pytest

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ For tests running on GitHub Actions, store the same JSON string in a repository
 secret named `SECRETS_JSON`. The `test.yml` workflow writes this value to
 `secrets.json` before executing `pytest`.
 
+Additionally, keep your Google Cloud Storage bucket name private by storing the
+GCS configuration JSON in a secret named `GCS_BUCKET_JSON`. This JSON should
+contain `gcs_bucket_name` and `gcs_weather_dir`. The workflows automatically
+write this secret to `src/conf/gcs_bucket.json`.
+
 3. Run tests
 
 ```bash

--- a/src/utils/weather.py
+++ b/src/utils/weather.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import requests
 from typing import Optional
@@ -12,11 +13,18 @@ class Weather:
     def __init__(self):
         from pathlib import Path
 
-        conf_path = Path(__file__).resolve().parent.parent / "conf" / "gcs_bucket.json"
-        with open(conf_path, "r", encoding="utf-8") as json_file:
-            config: dict = json.load(json_file)
-            self._gcs_bucket_name: str = config["gcs_bucket_name"]
-            self._gcs_weather_dir: str = config["gcs_weather_dir"]
+        env_json = os.getenv("GCS_BUCKET_JSON")
+        if env_json:
+            config: dict = json.loads(env_json)
+        else:
+            conf_path = (
+                Path(__file__).resolve().parent.parent / "conf" / "gcs_bucket.json"
+            )
+            with open(conf_path, "r", encoding="utf-8") as json_file:
+                config = json.load(json_file)
+
+        self._gcs_bucket_name: str = config["gcs_bucket_name"]
+        self._gcs_weather_dir: str = config["gcs_weather_dir"]
 
     def get(self, area_no: int = 130000):
         """Return weather data as a dictionary for the specified area."""


### PR DESCRIPTION
## Summary
- load GCS bucket config from `GCS_BUCKET_JSON` env variable if provided
- create `gcs_bucket.json` during CI using `GCS_BUCKET_JSON` secret
- document new secret in README

## Testing
- `black .`
- `pytest -q` *(fails: `pytest: command not found`)*