### PR TITLE
Add Slack thread history agent

### DIFF
--- a/src/agent/agent_slack_history.py
+++ b/src/agent/agent_slack_history.py
@@ -1,0 +1,20 @@
+from typing import Any, List
+
+from agent.agent_base import AgentSlack
+from agent.types import Chat
+from utils import slack_link_utils
+from utils import slack_message_utils
+
+
+class AgentSlackHistory(AgentSlack):
+    """Fetch Slack thread messages and return as single chat content."""
+
+    def execute(self, arguments: dict[str, Any], chat_history: List[Chat]) -> Chat:
+        url = str(arguments.get("url") or chat_history[-1].get("content", ""))
+        url = slack_link_utils.sanitize_url(url)
+        channel, ts = slack_message_utils.parse_message_url(url)
+        messages = slack_message_utils.fetch_thread_messages(
+            self._slack_behalf_user, channel, ts
+        )
+        history_text = "\n".join(messages)
+        return Chat(role="assistant", content=history_text)

--- a/src/function/generative_agent.py
+++ b/src/function/generative_agent.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict
 
 import utils.scraping_utils as scraping_utils
 import utils.slack_link_utils as slack_link_utils
+import utils.slack_message_utils as slack_message_utils
 from agent.agent_base import Agent, AgentDelete, AgentNotification, AgentText
 from agent.agent_gpt import AgentGPT
 from agent.agent_idea import AgentIdea
@@ -12,6 +13,7 @@ from agent.agent_quiz import AgentQuiz
 from agent.agent_recommend import AgentRecommend
 from agent.agent_search import AgentSearch
 from agent.agent_slack_mail import AgentSlackMail
+from agent.agent_slack_history import AgentSlackHistory
 from agent.agent_summarize import AgentSummarize
 from agent.agent_youtube import AgentYoutube
 from agent.types import Chat
@@ -76,7 +78,11 @@ class GenerativeAgent(GenerativeBase):
 
         if slack_link_utils.is_only_url(content):
             url: str = slack_link_utils.extract_and_remove_tracking_url(content)
-            if scraping_utils.is_allow_scraping(url):
+            if slack_message_utils.is_slack_message_url(url):
+                execute_queue.append(
+                    AgentExecute(agent=AgentSlackHistory, arguments={"url": url})
+                )
+            elif scraping_utils.is_allow_scraping(url):
                 execute_queue.append(
                     AgentExecute(
                         agent=command_dict["/summarize"],

--- a/src/utils/slack_message_utils.py
+++ b/src/utils/slack_message_utils.py
@@ -1,0 +1,35 @@
+import re
+from typing import Any, List, Tuple
+
+
+def is_slack_message_url(url: str) -> bool:
+    if not url:
+        return False
+    pattern = r"/archives/[A-Z0-9]+/p\d{16}"  # simple pattern
+    return bool(re.search(pattern, url))
+
+
+def parse_message_url(url: str) -> Tuple[str, str]:
+    """Return channel id and timestamp from Slack message URL."""
+    if not url:
+        raise ValueError("url is empty")
+    m = re.search(r"/archives/(?P<channel>[A-Z0-9]+)/p(?P<ts>\d{16})", url)
+    if not m:
+        raise ValueError("invalid slack message url")
+    channel = m.group("channel")
+    ts_raw = m.group("ts")
+    ts = f"{ts_raw[:-6]}.{ts_raw[-6:]}"
+    return channel, ts
+
+
+def fetch_thread_messages(
+    slack_cli: Any, channel: str, ts: str, limit: int = 20
+) -> List[str]:
+    history = slack_cli.conversations_replies(channel=channel, ts=ts, limit=limit)
+    messages: List[str] = []
+    for msg in history.get("messages", []):
+        if isinstance(msg, dict):
+            text = msg.get("text")
+            if text:
+                messages.append(text)
+    return messages

--- a/tests/function/test_generative_agent.py
+++ b/tests/function/test_generative_agent.py
@@ -1,6 +1,7 @@
 import pytest
 from agent.agent_gpt import AgentGPT
 from agent.agent_summarize import AgentSummarize
+from agent.agent_slack_history import AgentSlackHistory
 from function.generative_agent import AgentExecute, GenerativeAgent
 
 
@@ -91,3 +92,10 @@ def test_multi(pytestconfig: pytest.Config):
         ],
     )
     print(result)
+
+
+def test_slack_history():
+    url = "https://example.slack.com/archives/C999/p1700000000000000"
+    result = GenerativeAgent().generate(None, [{"role": "user", "content": url}])
+    expected = [AgentExecute(agent=AgentSlackHistory, arguments={"url": url})]
+    assert result == expected

--- a/tests/utils/test_slack_message_utils.py
+++ b/tests/utils/test_slack_message_utils.py
@@ -1,0 +1,31 @@
+import utils.slack_message_utils as slack_message_utils
+
+
+def test_parse_message_url():
+    url = "https://example.slack.com/archives/C123456/p1700000000000000"
+    channel, ts = slack_message_utils.parse_message_url(url)
+    assert channel == "C123456"
+    assert ts == "1700000000.000000"
+
+
+def test_is_slack_message_url():
+    url = "https://example.slack.com/archives/C123456/p1700000000000000"
+    assert slack_message_utils.is_slack_message_url(url)
+    assert not slack_message_utils.is_slack_message_url("https://example.com/")
+
+
+class DummySlack:
+    def __init__(self, messages):
+        self.messages = messages
+        self.calls = []
+
+    def conversations_replies(self, channel, ts, limit=20):
+        self.calls.append((channel, ts, limit))
+        return {"messages": [{"text": m} for m in self.messages]}
+
+
+def test_fetch_thread_messages():
+    client = DummySlack(["hi", "there"])
+    result = slack_message_utils.fetch_thread_messages(client, "C1", "1.0")
+    assert result == ["hi", "there"]
+    assert client.calls


### PR DESCRIPTION
## Summary
- add utility to parse Slack message URLs and fetch thread messages
- implement `AgentSlackHistory` to load thread content
- detect Slack message links in generative agent
- add unit tests for new utils and agent detection

## Testing
- `black . --check`
- `pytest -q` *(fails: command not found)*