### PR TITLE
Adjust Slack output timing

### DIFF
--- a/src/agent/agent_gemini.py
+++ b/src/agent/agent_gemini.py
@@ -26,7 +26,6 @@ class AgentGemini(AgentSlack):
         result_text = self.completion(prompt_messages)
         self.tik_process()
         blocks = self.build_message_blocks(result_text)
-        self.update_message(blocks)
         action_blocks = self.build_action_blocks(chat_history)
         blocks.append(action_blocks)
         self.update_message(blocks)

--- a/src/agent/agent_gpt.py
+++ b/src/agent/agent_gpt.py
@@ -41,8 +41,12 @@ class AgentGPT(AgentSlack):
             self.tik_process()
             content: str = ""
             if self._openai_stream:
-                for content in self.completion_stream(prompt_messages):
-                    self.update_message(self.build_message_blocks(content))
+                if self._collect_blocks is None:
+                    for content in self.completion_stream(prompt_messages):
+                        self.update_message(self.build_message_blocks(content))
+                else:
+                    for content in self.completion_stream(prompt_messages):
+                        pass
             else:
                 content = self.completion(prompt_messages)
             blocks: list[dict] = self.build_message_blocks(content)


### PR DESCRIPTION
## Summary
- collect Slack blocks during agent execution and post once with `flush_blocks`
- update GPT and Gemini agents to respect batching
- modify entrypoint to post a single message after all agents complete

## Testing
- `black .`
- `pytest -q` *(fails: command not found)*