### PR TITLE
Fix Cloud Run function deployment runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
                   gcloud -q functions deploy "$FUNCTION_NAME" \
                     --gen2 \
                     --region=asia-northeast1 \
-                    --runtime=python312 \
+                    --runtime=python311 \
                     --trigger-topic="$TRIGGER_TOPIC" \
                     --timeout=120s \
                     --min-instances=0 \

--- a/deploy.sh
+++ b/deploy.sh
@@ -11,7 +11,7 @@ fi
 DEPLOY_OUTPUT=$(gcloud -q functions deploy "${FUNCTION_NAME}" \
     --gen2 \
     --region=asia-northeast1 \
-    --runtime=python312 \
+    --runtime=python311 \
     --trigger-topic="${TRIGGER_TOPIC}" \
     --timeout=120s \
     --min-instances=0 \

--- a/local_deploy.sh
+++ b/local_deploy.sh
@@ -6,7 +6,7 @@ gcloud -q components update
 DEPLOY_OUTPUT=$(gcloud -q functions deploy ${FUNCTION_NAME} \
 	--gen2 \
 	--region=asia-northeast1 \
-	--runtime=python312 \
+        --runtime=python311 \
 	--trigger-topic=${TRIGGER_TOPIC} \
 	--timeout=120s \
 	--min-instances=0 \


### PR DESCRIPTION
## Summary
- use python311 runtime for Cloud Functions deployment

## Testing
- `black --check .`
- `pytest` *(fails: command not found)*