### PR TITLE
Refactor scraping utils headers

### DIFF
--- a/src/utils/scraping_utils.py
+++ b/src/utils/scraping_utils.py
@@ -9,6 +9,14 @@ import requests
 from bs4 import BeautifulSoup
 from pydantic import BaseModel, ConfigDict
 
+DEFAULT_HEADERS: dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/69.0.3497.100 Safari/537.36"
+    )
+}
+
 
 class SiteInfo(BaseModel):
     url: str = ""
@@ -92,21 +100,13 @@ def is_youtube_url(url: str) -> bool:
 
 
 def scraping_raw(url: str) -> str:
-    headers: dict[str, str] = {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6\
-) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
-    }
-    res = requests.get(url, timeout=(3.0, 8.0), headers=headers)
+    res = requests.get(url, timeout=(3.0, 8.0), headers=DEFAULT_HEADERS)
     res.raise_for_status()
     return res.text
 
 
 def scraping_pdf(url: str) -> SiteInfo:
-    headers: dict[str, str] = {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6\
-) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
-    }
-    res = requests.get(url, timeout=(3.0, 8.0), headers=headers)
+    res = requests.get(url, timeout=(3.0, 8.0), headers=DEFAULT_HEADERS)
     res.raise_for_status()
     with tempfile.NamedTemporaryFile(mode="wb+", delete=True) as t:
         t.write(res.content)


### PR DESCRIPTION
## Summary
- consolidate repeated User-Agent headers in scraping utils

## Testing
- `black . --check`
- `python3 -m pytest -q` *(fails: No module named pytest)*