### PR TITLE
Make tests optional without secrets

### DIFF
--- a/tests/agent/test_agent_base.py
+++ b/tests/agent/test_agent_base.py
@@ -1,4 +1,8 @@
+import os
 import pytest
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 
 from agent.agent_base import AgentSlack
 

--- a/tests/agent/test_agent_gpt.py
+++ b/tests/agent/test_agent_gpt.py
@@ -1,4 +1,8 @@
+import os
 import pytest
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 
 from agent.agent_gpt import AgentGPT
 

--- a/tests/agent/test_agent_idea.py
+++ b/tests/agent/test_agent_idea.py
@@ -1,5 +1,9 @@
 import collections
+import os
 import pytest
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 
 from agent.agent_idea import AgentIdea
 

--- a/tests/agent/test_agent_quiz.py
+++ b/tests/agent/test_agent_quiz.py
@@ -1,4 +1,9 @@
 import json
+import os
+import pytest
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 
 from agent.agent_quiz import AgentQuiz
 

--- a/tests/agent/test_agent_recommend.py
+++ b/tests/agent/test_agent_recommend.py
@@ -1,5 +1,9 @@
 import collections
+import os
 import pytest
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 
 from agent.agent_recommend import AgentRecommend
 

--- a/tests/agent/test_agent_search.py
+++ b/tests/agent/test_agent_search.py
@@ -1,9 +1,12 @@
 from typing import Any
 
+import os
 import pytest
-
 from agent.agent_search import AgentSearch
 from agent.types import Chat
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 
 
 def test_build_prompt_chat_history(pytestconfig: pytest.Config):

--- a/tests/agent/test_agent_slack_mail.py
+++ b/tests/agent/test_agent_slack_mail.py
@@ -1,7 +1,10 @@
 import collections
 import json
-
+import os
 import pytest
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 from unittest import mock
 
 from agent.agent_slack_mail import AgentSlackMail

--- a/tests/agent/test_agent_summarize.py
+++ b/tests/agent/test_agent_summarize.py
@@ -1,6 +1,10 @@
+import os
 import pytest
 from agent.agent_summarize import AgentSummarize
 from agent.types import Chat
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 
 
 def test_scraping(pytestconfig: pytest.Config):

--- a/tests/agent/test_agent_youtube.py
+++ b/tests/agent/test_agent_youtube.py
@@ -1,7 +1,9 @@
 import json
 import os
-
 import pytest
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 from agent.agent_youtube import AgentYoutube
 from agent.types import Chat
 

--- a/tests/function/test_generative_actions.py
+++ b/tests/function/test_generative_actions.py
@@ -1,4 +1,8 @@
+import os
 import pytest
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 
 from function.generative_actions import GenerativeActions
 

--- a/tests/function/test_generative_agent.py
+++ b/tests/function/test_generative_agent.py
@@ -1,4 +1,8 @@
+import os
 import pytest
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 from agent.agent_gpt import AgentGPT
 from agent.agent_summarize import AgentSummarize
 from agent.agent_slack_history import AgentSlackHistory

--- a/tests/function/test_generative_synonyms.py
+++ b/tests/function/test_generative_synonyms.py
@@ -1,4 +1,8 @@
+import os
 import pytest
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 
 from function.generative_synonyms import GenerativeSynonyms
 

--- a/tests/utils/test_scraping_utils.py
+++ b/tests/utils/test_scraping_utils.py
@@ -1,4 +1,9 @@
 import collections
+import os
+import pytest
+
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
 
 import utils.scraping_utils as scraping_utils
 

--- a/tests/utils/test_slack_search_utils.py
+++ b/tests/utils/test_slack_search_utils.py
@@ -1,17 +1,26 @@
 import json
+import os
+from pathlib import Path
 
 import pytest
 import slack_sdk
 
 import utils.slack_search_utils as slack_search_utils
 
-with open("secrets.json", "r", encoding="utf-8") as f:
-    secrets = json.load(f)
-    slack_user_token = secrets.get("SLACK_USER_TOKEN")
-    if not slack_user_token:
-        raise ValueError("slack_token not set.")
-    slack_cli: slack_sdk.WebClient = slack_sdk.WebClient(token=slack_user_token)
-    share_channel_id: str = secrets.get("SHARE_CHANNEL_ID")
+if os.getenv("SECRETS"):
+    secrets = json.loads(os.getenv("SECRETS"))
+elif Path("secrets.json").exists():
+    with open("secrets.json", "r", encoding="utf-8") as f:
+        secrets = json.load(f)
+else:
+    secrets = {}
+
+slack_user_token = secrets.get("SLACK_USER_TOKEN")
+share_channel_id = secrets.get("SHARE_CHANNEL_ID")
+if not slack_user_token or not share_channel_id:
+    pytest.skip("Slack secrets not set", allow_module_level=True)
+
+slack_cli: slack_sdk.WebClient = slack_sdk.WebClient(token=slack_user_token)
 
 
 def test_build_past_query_basic():

--- a/tests/utils/test_weather.py
+++ b/tests/utils/test_weather.py
@@ -2,6 +2,9 @@ import os
 
 import pytest
 
+if "SECRETS" not in os.environ:
+    pytest.skip("SECRETS not set", allow_module_level=True)
+
 import utils.weather
 
 


### PR DESCRIPTION
## Summary
- avoid running network-dependent tests when SECRETS is undefined
- fix duplicate imports in updated tests

## Testing
- `black .`
- `pytest` *(fails: command not found)*