### PR TITLE
Fix Slack bookmark parameters

### DIFF
--- a/src/agent/agent_slack_mail.py
+++ b/src/agent/agent_slack_mail.py
@@ -36,7 +36,7 @@ class AgentSlackMail(AgentGPT):
                 self._slack.api_call(
                     "bookmarks.add",
                     json={
-                        "channel": self._channel,
+                        "channel_id": self._channel,
                         "title": self._mail.subject or "mail",
                         "type": "message",
                         "entity_id": self._ts,

--- a/tests/agent/test_agent_slack_mail.py
+++ b/tests/agent/test_agent_slack_mail.py
@@ -52,4 +52,13 @@ def test_execute_adds_bookmark(pytestconfig: pytest.Config):
     ]
     with mock.patch.object(agent._slack, "api_call") as mock_call:
         agent.execute({}, messages)
-        mock_call.assert_called()
+        mock_call.assert_called_with(
+            "bookmarks.add",
+            json={
+                "channel_id": "C123",
+                "title": "sub",
+                "type": "message",
+                "entity_id": "123.45",
+                "emoji": ":email:",
+            },
+        )


### PR DESCRIPTION
## Summary
- use `channel_id` for Slack bookmarks
- test bookmark payload

## Testing
- `black .`
- `python -m pytest` *(fails: No module named pytest)*