### PR TITLE
Update mail bookmark emoji

### DIFF
--- a/src/agent/agent_slack_mail.py
+++ b/src/agent/agent_slack_mail.py
@@ -95,3 +95,15 @@ class AgentSlackMail(AgentGPT):
             current_content += line + "\n"
         blocks.append({"type": "markdown", "text": current_content})
         return blocks
+
+    def execute(self, arguments: dict[str, Any], chat_history: List[Chat]) -> Chat:
+        result: Chat = super().execute(arguments, chat_history)
+        self._slack.api_call(
+            "reactions.add",
+            json={
+                "channel": self._channel,
+                "name": "bookmark",
+                "timestamp": self._ts,
+            },
+        )
+        return result

--- a/tests/agent/test_agent_slack_mail.py
+++ b/tests/agent/test_agent_slack_mail.py
@@ -56,12 +56,10 @@ def test_execute_adds_bookmark(pytestconfig: pytest.Config):
     with mock.patch.object(agent._slack, "api_call") as mock_call:
         agent.execute({}, messages)
         mock_call.assert_called_with(
-            "bookmarks.add",
+            "reactions.add",
             json={
-                "channel_id": "C123",
-                "title": "sub",
-                "type": "message",
-                "entity_id": "123.45",
-                "emoji": ":email:",
+                "channel": "C123",
+                "name": "bookmark",
+                "timestamp": "123.45",
             },
         )


### PR DESCRIPTION
## Summary
- react to processed mail with :bookmark: instead of adding a bookmark
- expect `reactions.add` call in Slack mail agent test

## Testing
- `black . --check`
- `pytest -q` *(fails: command not found)*